### PR TITLE
Display license info upon installation on win32 machines

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "test": "xo && stylelint 'src/style/*.css'",
-    "release": "build --publish always",
+    "release": "build --win --x64",
     "start": "electron ."
   },
   "dependencies": {
@@ -103,6 +103,9 @@
           ]
         }
       ]
+    },
+    "nsis": {
+      "license": "license.md"
     },
     "snap": {
       "grade": "stable",


### PR DESCRIPTION
## Description

Display the MIT license, as a dedicated step of the installation process, on x68/ia32 Win32 machines;

<p align="center"><img width="80%" src="https://user-images.githubusercontent.com/12670537/51411068-353caf00-1b6f-11e9-985c-0c4eebb9ba75.png">
</p>
