### PR TITLE
Redirect url for Yinxiang

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const {app, BrowserWindow, ipcMain, Menu, shell} = require('electron');
 const fs = require('fs');
-const {is, formatTitle, formatURL, readSheet} = require('./src/util');
+const {is, formatTitle, formatURL, formatYinxiangURL, readSheet} = require('./src/util');
 const file = require('./src/file');
 const menu = require('./src/menu');
 const pdf = require('./src/pdf');
@@ -95,7 +95,7 @@ app.on('ready', () => {
 
   webContents.on('new-window', (e, url) => {
     e.preventDefault();
-    url = formatURL(url);
+    url = settings.get('useYinxiang') ? formatYinxiangURL(url) : formatURL(url);
 
     if (is.downloadURL(url)) {
       webContents.downloadURL(url);

--- a/src/url.js
+++ b/src/url.js
@@ -14,5 +14,6 @@ module.exports = {
   settings: 'https://www.evernote.com/Settings.action',
   source: 'https://github.com/klaussinani/tusk',
   update: 'https://klaussinani.github.io/tusk/update.json',
-  yinxiang: 'https://app.yinxiang.com/Login.action'
+  yinxiang: 'https://app.yinxiang.com/Login.action',
+  yinxiangRedirect: 'https://app.yinxiang.com/OutboundRedirect.action?dest=',
 };

--- a/src/util.js
+++ b/src/util.js
@@ -40,6 +40,10 @@ class Util {
     return decodeUri(x.replace(url.redirect, ''));
   }
 
+  formatYinxiangURL(x) {
+    return decodeUri(x.replace(url.yinxiangRedirect, ''));
+  }
+
   readSheet(x) {
     return fs.readFileSync(join(__dirname, './style', x), 'utf8');
   }


### PR DESCRIPTION
Fixed a minor bug for Yinxiang users.

When I click a link in note, Tusk will open a url like **https://app.yinxiang.com/OutboundRedirect.action?dest=https://screencloud.net/**. The **FormatURL** doesn't replace yinxiang redirect url.

This PL will fix it.