### PR TITLE
Update Mac brew command and link to cask formulae.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,7 +70,7 @@ Ubuntu Linux users can directly install through [Snapcraft](https://snapcraft.io
 
 #### Homebrew
 
-Macos users can directly install through [Homebrew Cask](https://caskroom.github.io/) `brew cask install tusk`
+Macos users can directly install through [Homebrew Cask](https://formulae.brew.sh/cask/tusk) `brew install --cask tusk`
 
 #### Note
 


### PR DESCRIPTION
- use of `brew cask` is deprecated. Use `brew install --cask`instead.
- update link to tusk formulae instead of old

<!--

Thank you for taking the time to contribute to Tusk! ✨🎉

For more info on how to contribute to the project, please read the [contributing guidelines](https://github.com/klaussinani/tusk/blob/master/contributing.md).

We are always excited about pull requests!
If the pull request fixes any open issues, reference the corresponding issues in the following fashion: `Fixes #321`.
Including test results/screenshots/.gifs (if applicable/possible) alongside new features and bug fixes is something that we strongly encourage!

Thank you so much again for all of your time invested in the project!

-->
