### PR TITLE
Fix xo errors (test script)

### DIFF
--- a/src/nav.js
+++ b/src/nav.js
@@ -5,7 +5,7 @@ const settings = require('./settings');
 
 class Nav {
   constructor() {
-    this._defaultZoomFactor = 1.0;
+    this._defaultZoomFactor = 1;
     this._lowerZoomLimit = 0.7;
     this._noteSelector = '.focus-NotesView-Note';
     this._notesList = '.NotesView-ScrollWindow > div';
@@ -17,18 +17,10 @@ class Nav {
   }
 
   _currentIdx() {
-    let currentIdx = 0;
-
     const selectedNote = document.querySelector(this._selectedNoteSelector);
     const notesArray = document.querySelector(this._notesListSelector).querySelectorAll(this._noteSelector);
 
-    for (let i = 0; i < notesArray.length; i++) {
-      if (notesArray[i] === selectedNote) {
-        currentIdx = i + 1;
-      }
-    }
-
-    return currentIdx;
+    return notesArray.findIndex(note => note === selectedNote) + 1;
   }
 
   _scrollUp() {


### PR DESCRIPTION
This PR aims to fix the "errors" in the `test` script output, which is currently failing and showing:

```
src/nav.js:8:31
  ✖   8:31  Don't use a zero fraction in the number.     unicorn/no-zero-fractions
  ✖  25:5   Use a for-of loop instead of this for loop.  unicorn/no-for-loop

  2 errors
```